### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       run: echo '::set-env name=QUAY_TAG_EXPIRATION::1w'
     - name: Publish Installer to Registry
       if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-      uses: elgohr/Publish-Docker-Github-Action@2.15
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: assisted-installer
         username: ${{ secrets.OCPMETAL_USERNAME }}
@@ -46,7 +46,7 @@ jobs:
         tags: "PR_${{ env.GIT_REVISION }}"
     - name: Publish Controller to Registry
       if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-      uses: elgohr/Publish-Docker-Github-Action@2.15
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: assisted-installer-controller
         username: ${{ secrets.OCPMETAL_USERNAME }}
@@ -58,7 +58,7 @@ jobs:
     - name: Publish Installer to Registry with latest tag
       # Publish the image with latest tag only in case of push to master
       if: github.event_name != 'pull_request'
-      uses: elgohr/Publish-Docker-Github-Action@2.15
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: assisted-installer
         username: ${{ secrets.OCPMETAL_USERNAME }}
@@ -70,7 +70,7 @@ jobs:
     - name: Publish Controller to Registry with latest tag
       # Publish the image with latest tag only in case of push to master
       if: github.event_name != 'pull_request'
-      uses: elgohr/Publish-Docker-Github-Action@2.15
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: assisted-installer-controller
         username: ${{ secrets.OCPMETAL_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         id: get_tag
         run: echo ::set-env name=GIT_TAG::${GITHUB_REF/refs\/tags\//}
       - name: Publish Installer to Registry
-        uses: elgohr/Publish-Docker-Github-Action@2.15
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: assisted-installer
           username: ${{ secrets.OCPMETAL_USERNAME }}
@@ -43,7 +43,7 @@ jobs:
       - name: Publish Controller to Registry
         # Publish the image only in case of push to master
         if: github.event_name != 'pull_request'
-        uses: elgohr/Publish-Docker-Github-Action@2.15
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: assisted-installer-controller
           username: ${{ secrets.OCPMETAL_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore